### PR TITLE
Fix resourcequantity serialization with type converter

### DIFF
--- a/Devantler.KubernetesGenerator.Core/BaseKubernetesGenerator.cs
+++ b/Devantler.KubernetesGenerator.Core/BaseKubernetesGenerator.cs
@@ -1,3 +1,5 @@
+using Devantler.KubernetesGenerator.Core.Converters;
+using Devantler.KubernetesGenerator.Core.Inspectors;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 using YamlDotNet.System.Text.Json;
@@ -13,6 +15,7 @@ public class BaseKubernetesGenerator<T> : IKubernetesGenerator<T> where T : clas
 {
   readonly ISerializer _serializer = new SerializerBuilder()
     .WithTypeInspector(inner => new KubernetesTypeInspector(new SystemTextJsonTypeInspector(inner)))
+    .WithTypeConverter(new ResourceQuantityTypeConverter())
     .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitNull)
     .WithNamingConvention(CamelCaseNamingConvention.Instance).Build();
 

--- a/Devantler.KubernetesGenerator.Core/Converters/ResourceQuantityTypeConverter.cs
+++ b/Devantler.KubernetesGenerator.Core/Converters/ResourceQuantityTypeConverter.cs
@@ -1,0 +1,27 @@
+using k8s.Models;
+using YamlDotNet.Core;
+using YamlDotNet.Core.Events;
+using YamlDotNet.Serialization;
+
+namespace Devantler.KubernetesGenerator.Core.Converters;
+
+/// <summary>
+/// A JSON converter for <see cref="ResourceQuantity"/> that serializes it as a string.
+/// </summary>
+public class ResourceQuantityTypeConverter : IYamlTypeConverter
+{
+  /// <inheritdoc/>
+  public bool Accepts(Type type) => type == typeof(ResourceQuantity);
+
+  /// <inheritdoc/>
+  public object? ReadYaml(IParser parser, Type type, ObjectDeserializer rootDeserializer) => null;
+
+  /// <inheritdoc/>
+  public void WriteYaml(IEmitter emitter, object? value, Type type, ObjectSerializer serializer)
+  {
+    if (value is ResourceQuantity resourceQuantity)
+    {
+      emitter?.Emit(new Scalar(resourceQuantity.Value));
+    }
+  }
+}

--- a/Devantler.KubernetesGenerator.Core/Converters/ResourceQuantityTypeConverter.cs
+++ b/Devantler.KubernetesGenerator.Core/Converters/ResourceQuantityTypeConverter.cs
@@ -14,7 +14,8 @@ public class ResourceQuantityTypeConverter : IYamlTypeConverter
   public bool Accepts(Type type) => type == typeof(ResourceQuantity);
 
   /// <inheritdoc/>
-  public object? ReadYaml(IParser parser, Type type, ObjectDeserializer rootDeserializer) => null;
+  public object? ReadYaml(IParser parser, Type type, ObjectDeserializer rootDeserializer) =>
+    parser?.Current is Scalar scalar ? new ResourceQuantity(scalar.Value) : (object?)null;
 
   /// <inheritdoc/>
   public void WriteYaml(IEmitter emitter, object? value, Type type, ObjectSerializer serializer)

--- a/Devantler.KubernetesGenerator.Core/Inspectors/KubernetesTypeInspector.cs
+++ b/Devantler.KubernetesGenerator.Core/Inspectors/KubernetesTypeInspector.cs
@@ -1,8 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
-using k8s.Models;
 using YamlDotNet.Serialization;
 
-namespace Devantler.KubernetesGenerator.Core;
+namespace Devantler.KubernetesGenerator.Core.Inspectors;
 
 /// <summary>
 /// A type inspector that prioritizes properties of Kubernetes resources, so they come first, and so they are ordered according to conventions.
@@ -34,7 +33,6 @@ sealed class KubernetesTypeInspector(ITypeInspector inner) : ITypeInspector
       }
     }
 
-
     foreach (var property in properties)
     {
       if (property.Type == typeof(Uri))
@@ -42,12 +40,7 @@ sealed class KubernetesTypeInspector(ITypeInspector inner) : ITypeInspector
         skipped.Add(property.Name);
         yield return new PropertyDescriptor(property) { TypeOverride = typeof(string) };
       }
-      if (property.Type == typeof(ResourceQuantity))
-      {
-        skipped.Add(property.Name);
-        yield return new PropertyDescriptor(property) { TypeOverride = typeof(string) };
-      }
-      if (!skipped.Contains(property.Name))
+      else if (!skipped.Contains(property.Name))
       {
         yield return property;
       }

--- a/Devantler.KubernetesGenerator.Native.Tests/ClusterTests/PersistentVolumeGeneratorTests/GenerateAsyncTests.GenerateAsync_WithAllPropertiesSet_ShouldGenerateAValidPersistentVolume.verified.txt
+++ b/Devantler.KubernetesGenerator.Native.Tests/ClusterTests/PersistentVolumeGeneratorTests/GenerateAsyncTests.GenerateAsync_WithAllPropertiesSet_ShouldGenerateAValidPersistentVolume.verified.txt
@@ -8,9 +8,7 @@ spec:
   accessModes:
   - ReadWriteOnce
   capacity:
-    storage:
-      format: BinarySI
-      value: 1Gi
+    storage: 1Gi
   claimRef:
     apiVersion: v1
     kind: PersistentVolumeClaim

--- a/Devantler.KubernetesGenerator.Native.Tests/ClusterTests/ResourceQuotaGeneratorTests/GenerateAsyncTests.GenerateAsync_WithAllPropertiesSet_ShouldGenerateAValidResourceQuota.verified.txt
+++ b/Devantler.KubernetesGenerator.Native.Tests/ClusterTests/ResourceQuotaGeneratorTests/GenerateAsyncTests.GenerateAsync_WithAllPropertiesSet_ShouldGenerateAValidResourceQuota.verified.txt
@@ -6,11 +6,7 @@ metadata:
   namespace: default
 spec:
   hard:
-    requests.cpu: &o0
-      format: DecimalSI
-      value: 1
-    requests.memory: &o1
-      format: BinarySI
-      value: 1Gi
-    limits.cpu: *o0
-    limits.memory: *o1
+    requests.cpu: 1
+    requests.memory: 1Gi
+    limits.cpu: 1
+    limits.memory: 1Gi

--- a/Devantler.KubernetesGenerator.Native.Tests/ClusterTests/RuntimeClassGeneratorTests/GenerateAsyncTests.GenerateAsync_WithAllPropertiesSet_ShouldGenerateAValidRuntimeClass.verified.txt
+++ b/Devantler.KubernetesGenerator.Native.Tests/ClusterTests/RuntimeClassGeneratorTests/GenerateAsyncTests.GenerateAsync_WithAllPropertiesSet_ShouldGenerateAValidRuntimeClass.verified.txt
@@ -7,9 +7,7 @@ metadata:
 handler: handler
 overhead:
   podFixed:
-    key:
-      format: DecimalSI
-      value: 1
+    key: 1
 scheduling:
   nodeSelector:
     key: value

--- a/Devantler.KubernetesGenerator.Native.Tests/ConfigAndStorageTests/PersistentVolumeClaimGeneratorTests/GenerateAsyncTests.GenerateAsync_WithAllPropertiesSet_ShouldGenerateAValidPersistentVolumeClaim.verified.txt
+++ b/Devantler.KubernetesGenerator.Native.Tests/ConfigAndStorageTests/PersistentVolumeClaimGeneratorTests/GenerateAsyncTests.GenerateAsync_WithAllPropertiesSet_ShouldGenerateAValidPersistentVolumeClaim.verified.txt
@@ -18,9 +18,7 @@ spec:
     namespace: default
   resources:
     requests:
-      storage:
-        format: BinarySI
-        value: 1Gi
+      storage: 1Gi
   selector:
     matchLabels:
       key: value

--- a/Devantler.KubernetesGenerator.Native.Tests/MetadataTests/LimitRangeGeneratorTests/GenerateAsyncTests.GenerateAsync_WithAllPropertiesSet_ShouldGenerateAValidLimitRange.verified.txt
+++ b/Devantler.KubernetesGenerator.Native.Tests/MetadataTests/LimitRangeGeneratorTests/GenerateAsyncTests.GenerateAsync_WithAllPropertiesSet_ShouldGenerateAValidLimitRange.verified.txt
@@ -8,27 +8,17 @@ spec:
   limits:
   - type: Pod
     default:
-      cpu: &o0
-        format: DecimalSI
-        value: 100m
-      memory: &o1
-        format: BinarySI
-        value: 100Mi
+      cpu: 100m
+      memory: 100Mi
     defaultRequest:
-      cpu: *o0
-      memory: *o1
+      cpu: 100m
+      memory: 100Mi
     max:
-      cpu:
-        format: DecimalSI
-        value: 1
-      memory:
-        format: BinarySI
-        value: 1Gi
+      cpu: 1
+      memory: 1Gi
     maxLimitRequestRatio:
-      cpu: &o2
-        format: DecimalSI
-        value: 10
-      memory: *o2
+      cpu: 10
+      memory: 10
     min:
-      cpu: *o0
-      memory: *o1
+      cpu: 100m
+      memory: 100Mi


### PR DESCRIPTION
This pull request fixes an issue with the serialization of the `ResourceQuantity` type. It includes a new type converter, `ResourceQuantityTypeConverter`, that serializes `ResourceQuantity` as a string. This ensures that the `ResourceQuantity` values are properly serialized when generating Kubernetes resources.