### PR TITLE
Add components to Kustomize Kustomization

### DIFF
--- a/Devantler.KubernetesGenerator.Kustomize.Tests/KustomizeKustomizationGeneratorTests/GenerateAsyncTests.cs
+++ b/Devantler.KubernetesGenerator.Kustomize.Tests/KustomizeKustomizationGeneratorTests/GenerateAsyncTests.cs
@@ -104,6 +104,10 @@ public class GenerateAsyncTests
             Annotations = ["zone=west"]
           }
         }
+      ],
+      Components = [
+        "component1.yaml",
+        "component2.yaml"
       ]
     };
 

--- a/Devantler.KubernetesGenerator.Kustomize.Tests/KustomizeKustomizationGeneratorTests/kustomization.full.yaml.verified.yaml
+++ b/Devantler.KubernetesGenerator.Kustomize.Tests/KustomizeKustomizationGeneratorTests/kustomization.full.yaml.verified.yaml
@@ -60,3 +60,6 @@ patches:
   options:
     allowNameChange: true
     allowKindChange: true
+components:
+- component1.yaml
+- component2.yaml

--- a/Devantler.KubernetesGenerator.Kustomize/Models/KustomizeKustomization.cs
+++ b/Devantler.KubernetesGenerator.Kustomize/Models/KustomizeKustomization.cs
@@ -37,4 +37,10 @@ public class KustomizeKustomization
   /// A kustomize feature to apply customizations to existing resources.
   /// </summary>
   public IEnumerable<KustomizePatch>? Patches { get; set; }
+
+  /// <summary>
+  /// A kustomize feature to apply components to the kustomization.
+  /// </summary>
+  public IEnumerable<string>? Components { get; set; }
+
 }


### PR DESCRIPTION
This pull request adds the ability to include components in the Kustomize Kustomization. The `Components` property has been added to the `KustomizeKustomization` class, allowing users to specify the components they want to include. This feature enhances the flexibility and customization options of Kustomize.