### PR TITLE
Add support for the 'kind' Kubernetes distribution

### DIFF
--- a/Devantler.KubernetesGenerator.KSail/Models/KSailKubernetesDistribution.cs
+++ b/Devantler.KubernetesGenerator.KSail/Models/KSailKubernetesDistribution.cs
@@ -11,5 +11,11 @@ public enum KSailKubernetesDistribution
   /// The k3d Kubernetes distribution.
   /// </summary>
   [EnumMember(Value = "k3d")]
-  K3d
+  K3d,
+
+  /// <summary>
+  /// The kind Kubernetes distribution.
+  /// </summary>
+  [EnumMember(Value = "kind")]
+  Kind
 }


### PR DESCRIPTION
This pull request adds support for the 'kind' Kubernetes distribution. The 'kind' distribution is now included as an option in the `KSailKubernetesDistribution` enum.