### PR TITLE
Add KSailContainerEngine to KSailCluster config

### DIFF
--- a/Devantler.KubernetesGenerator.KSail/Models/KSailClusterSpec.cs
+++ b/Devantler.KubernetesGenerator.KSail/Models/KSailClusterSpec.cs
@@ -18,6 +18,11 @@ public class KSailClusterSpec
   public KSailGitOpsTool? GitOpsTool { get; set; }
 
   /// <summary>
+  /// The container engine to use for the KSail cluster.
+  /// </summary>
+  public KSailContainerEngine? ContainerEngine { get; set; }
+
+  /// <summary>
   /// The registries to create for the KSail cluster to reconcile flux artifacts, and to proxy and cache images.
   /// </summary>
   public IEnumerable<KSailRegistry>? Registries { get; set; }

--- a/Devantler.KubernetesGenerator.KSail/Models/KSailContainerEngine.cs
+++ b/Devantler.KubernetesGenerator.KSail/Models/KSailContainerEngine.cs
@@ -1,0 +1,12 @@
+namespace Devantler.KubernetesGenerator.KSail.Models;
+
+/// <summary>
+/// The container engine to use for the KSail cluster.
+/// </summary>
+public enum KSailContainerEngine
+{
+  /// <summary>
+  /// Docker container engine.
+  /// </summary>
+  Docker
+}


### PR DESCRIPTION
This pull request adds the `KSailContainerEngine` property to the `KSailClusterSpec` class, allowing users to specify the container engine to use for the KSail cluster. The `KSailContainerEngine` enum is also added, with the initial option being `Docker`.