### PR TITLE
Add KSail command options for check, debug, down, gen, init, list, sops, start, stop, up, and update commands

### DIFF
--- a/Devantler.KubernetesGenerator.KSail.Tests/KSailClusterGeneratorTests/GenerateAsyncTests.cs
+++ b/Devantler.KubernetesGenerator.KSail.Tests/KSailClusterGeneratorTests/GenerateAsyncTests.cs
@@ -1,5 +1,17 @@
 using Devantler.KubernetesGenerator.KSail.Models;
+using Devantler.KubernetesGenerator.KSail.Models.Check;
+using Devantler.KubernetesGenerator.KSail.Models.Debug;
+using Devantler.KubernetesGenerator.KSail.Models.Down;
+using Devantler.KubernetesGenerator.KSail.Models.Gen;
+using Devantler.KubernetesGenerator.KSail.Models.Init;
+using Devantler.KubernetesGenerator.KSail.Models.Lint;
+using Devantler.KubernetesGenerator.KSail.Models.List;
 using Devantler.KubernetesGenerator.KSail.Models.Registry;
+using Devantler.KubernetesGenerator.KSail.Models.Sops;
+using Devantler.KubernetesGenerator.KSail.Models.Start;
+using Devantler.KubernetesGenerator.KSail.Models.Stop;
+using Devantler.KubernetesGenerator.KSail.Models.Up;
+using Devantler.KubernetesGenerator.KSail.Models.Update;
 using k8s.Models;
 
 namespace Devantler.KubernetesGenerator.KSail.Tests.KSailClusterGeneratorTests;
@@ -25,8 +37,16 @@ public class GenerateAsyncTests
       },
       Spec = new KSailClusterSpec
       {
+        Kubeconfig = "./.kube/config",
+        Context = "my-cluster",
+        Timeout = 300,
+        ManifestsDirectory = "./k8s",
+        KustomizationDirectory = "./clusters/my-cluster/flux-system",
+        ConfigPath = "./k3d-config.yaml",
         Distribution = KSailKubernetesDistribution.K3d,
         GitOpsTool = KSailGitOpsTool.Flux,
+        ContainerEngine = KSailContainerEngine.Docker,
+        Sops = true,
         Registries =
         [
           new KSailRegistry
@@ -89,7 +109,53 @@ public class GenerateAsyncTests
             },
             HostPort = 5005
           }
-        ]
+        ],
+        CheckOptions = new KSailCheckOptions
+        {
+        },
+        DebugOptions = new KSailDebugOptions
+        {
+          Editor = DebugEditor.Nano
+        },
+        DownOptions = new KSailDownOptions
+        {
+          Registries = true
+        },
+        GenOptions = new KSailGenOptions
+        {
+        },
+        InitOptions = new KSailInitOptions
+        {
+          Template = KSailInitTemplate.FluxDefault,
+          Components = true,
+          HelmReleases = true,
+          PostBuildVariables = true
+        },
+        LintOptions = new KSailLintOptions
+        {
+        },
+        ListOptions = new KSailListOptions
+        {
+        },
+        SopsOptions = new KSailSopsOptions
+        {
+        },
+        StartOptions = new KSailStartOptions
+        {
+        },
+        StopOptions = new KSailStopOptions
+        {
+        },
+        UpOptions = new KSailUpOptions
+        {
+          Lint = true,
+          Reconcile = true,
+        },
+        UpdateOptions = new KSailUpdateOptions
+        {
+          Lint = true,
+          Reconcile = true,
+        }
       }
     };
 

--- a/Devantler.KubernetesGenerator.KSail.Tests/KSailClusterGeneratorTests/ksail-config.full.yaml.verified.yaml
+++ b/Devantler.KubernetesGenerator.KSail.Tests/KSailClusterGeneratorTests/ksail-config.full.yaml.verified.yaml
@@ -4,8 +4,16 @@ kind: Cluster
 metadata:
   name: my-cluster
 spec:
+  kubeconfig: ./.kube/config
+  context: my-cluster
+  timeout: 300
+  manifestsDirectory: ./k8s
+  kustomizationDirectory: ./clusters/my-cluster/flux-system
+  configPath: ./k3d-config.yaml
   distribution: k3d
   gitOpsTool: flux
+  containerEngine: docker
+  sops: true
   registries:
   - name: ksail-registry
     hostPort: 5000
@@ -41,3 +49,25 @@ spec:
     proxy:
       url: https://quay.io/
     provider: docker
+  checkOptions: {}
+  debugOptions:
+    editor: nano
+  downOptions:
+    registries: true
+  genOptions: {}
+  initOptions:
+    components: true
+    helmReleases: true
+    postBuildVariables: true
+    template: flux-default
+  lintOptions: {}
+  listOptions: {}
+  sopsOptions: {}
+  startOptions: {}
+  stopOptions: {}
+  upOptions:
+    lint: true
+    reconcile: true
+  updateOptions:
+    lint: true
+    reconcile: true

--- a/Devantler.KubernetesGenerator.KSail/Models/Check/KSailCheckOptions.cs
+++ b/Devantler.KubernetesGenerator.KSail/Models/Check/KSailCheckOptions.cs
@@ -1,0 +1,8 @@
+namespace Devantler.KubernetesGenerator.KSail.Models.Check;
+
+/// <summary>
+/// The options to use for the 'check' command.
+/// </summary>
+public class KSailCheckOptions
+{
+}

--- a/Devantler.KubernetesGenerator.KSail/Models/Debug/DebugEditor.cs
+++ b/Devantler.KubernetesGenerator.KSail/Models/Debug/DebugEditor.cs
@@ -1,0 +1,25 @@
+using System.Runtime.Serialization;
+
+namespace Devantler.KubernetesGenerator.KSail.Models.Debug;
+
+/// <summary>
+/// The editor to use for viewing files while debugging.
+/// </summary>
+public enum DebugEditor
+{
+  /// <summary>
+  /// Visual Studio Code
+  /// </summary>
+  [EnumMember(Value = "vscode")]
+  VisualStudioCode,
+  /// <summary>
+  /// Nano
+  /// </summary>
+  [EnumMember(Value = "nano")]
+  Nano,
+  /// <summary>
+  /// Vim
+  /// </summary>
+  [EnumMember(Value = "vim")]
+  Vim
+}

--- a/Devantler.KubernetesGenerator.KSail/Models/Debug/KSailDebugOptions.cs
+++ b/Devantler.KubernetesGenerator.KSail/Models/Debug/KSailDebugOptions.cs
@@ -10,22 +10,3 @@ public class KSailDebugOptions
   /// </summary>
   public DebugEditor? Editor { get; set; }
 }
-
-/// <summary>
-/// The editor to use for viewing files while debugging.
-/// </summary>
-public enum DebugEditor
-{
-  /// <summary>
-  /// Visual Studio Code
-  /// </summary>
-  VisualStudioCode,
-  /// <summary>
-  /// Nano
-  /// </summary>
-  Nano,
-  /// <summary>
-  /// Vim
-  /// </summary>
-  Vim
-}

--- a/Devantler.KubernetesGenerator.KSail/Models/Debug/KSailDebugOptions.cs
+++ b/Devantler.KubernetesGenerator.KSail/Models/Debug/KSailDebugOptions.cs
@@ -1,0 +1,31 @@
+namespace Devantler.KubernetesGenerator.KSail.Models.Debug;
+
+/// <summary>
+/// The options to use for the 'debug' command.
+/// </summary>
+public class KSailDebugOptions
+{
+  /// <summary>
+  /// The editor to use for viewing files while debugging.
+  /// </summary>
+  public DebugEditor? Editor { get; set; }
+}
+
+/// <summary>
+/// The editor to use for viewing files while debugging.
+/// </summary>
+public enum DebugEditor
+{
+  /// <summary>
+  /// Visual Studio Code
+  /// </summary>
+  VisualStudioCode,
+  /// <summary>
+  /// Nano
+  /// </summary>
+  Nano,
+  /// <summary>
+  /// Vim
+  /// </summary>
+  Vim
+}

--- a/Devantler.KubernetesGenerator.KSail/Models/Down/KSailDownOptions.cs
+++ b/Devantler.KubernetesGenerator.KSail/Models/Down/KSailDownOptions.cs
@@ -1,0 +1,12 @@
+namespace Devantler.KubernetesGenerator.KSail.Models.Down;
+
+/// <summary>
+/// The options to use for the 'down' command.
+/// </summary>
+public class KSailDownOptions
+{
+  /// <summary>
+  /// Whether to remove ksail registries (will remove all cached images).
+  /// </summary>
+  public bool? Registries { get; set; }
+}

--- a/Devantler.KubernetesGenerator.KSail/Models/Gen/KSailGenOptions.cs
+++ b/Devantler.KubernetesGenerator.KSail/Models/Gen/KSailGenOptions.cs
@@ -1,0 +1,8 @@
+namespace Devantler.KubernetesGenerator.KSail.Models.Gen;
+
+/// <summary>
+/// The options to use for the 'gen' command.
+/// </summary>
+public class KSailGenOptions
+{
+}

--- a/Devantler.KubernetesGenerator.KSail/Models/Init/KSailInitOptions.cs
+++ b/Devantler.KubernetesGenerator.KSail/Models/Init/KSailInitOptions.cs
@@ -6,11 +6,6 @@ namespace Devantler.KubernetesGenerator.KSail.Models.Init;
 public class KSailInitOptions
 {
   /// <summary>
-  /// The output directory for the generated files.
-  /// </summary>
-  public string? Output { get; set; }
-
-  /// <summary>
   /// Whether to include Kustomize components in the generated output.
   /// </summary>
   public bool? Components { get; set; }
@@ -23,7 +18,7 @@ public class KSailInitOptions
   /// <summary>
   /// Whether to include post build variables in the generated output (flux feature).
   /// </summary>
-  public bool? Variables { get; set; }
+  public bool? PostBuildVariables { get; set; }
 
   /// <summary>
   /// The template to use for the generated output.

--- a/Devantler.KubernetesGenerator.KSail/Models/Init/KSailInitOptions.cs
+++ b/Devantler.KubernetesGenerator.KSail/Models/Init/KSailInitOptions.cs
@@ -1,0 +1,32 @@
+namespace Devantler.KubernetesGenerator.KSail.Models.Init;
+
+/// <summary>
+/// The options to use for the 'init' command.
+/// </summary>
+public class KSailInitOptions
+{
+  /// <summary>
+  /// The output directory for the generated files.
+  /// </summary>
+  public string? Output { get; set; }
+
+  /// <summary>
+  /// Whether to include Kustomize components in the generated output.
+  /// </summary>
+  public bool? Components { get; set; }
+
+  /// <summary>
+  /// Whether to include Helm Releases in the generated output.
+  /// </summary>
+  public bool? HelmReleases { get; set; }
+
+  /// <summary>
+  /// Whether to include post build variables in the generated output (flux feature).
+  /// </summary>
+  public bool? Variables { get; set; }
+
+  /// <summary>
+  /// The template to use for the generated output.
+  /// </summary>
+  public KSailInitTemplate? Template { get; set; }
+}

--- a/Devantler.KubernetesGenerator.KSail/Models/Init/KSailInitTemplate.cs
+++ b/Devantler.KubernetesGenerator.KSail/Models/Init/KSailInitTemplate.cs
@@ -1,0 +1,21 @@
+using System.Runtime.Serialization;
+
+namespace Devantler.KubernetesGenerator.KSail.Models.Init;
+
+/// <summary>
+/// The template to use for initializing a KSail cluster.
+/// </summary>
+public enum KSailInitTemplate
+{
+  /// <summary>
+  /// The default template for initializing a KSail cluster with Flux and a minimal Kustomize setup.
+  /// </summary>
+  [EnumMember(Value = "flux-default")]
+  FluxDefault,
+
+  /// <summary>
+  /// An advanced template for initializing a KSail cluster with Flux and a scalable Kustomize setup.
+  /// </summary>
+  [EnumMember(Value = "flux-advanced")]
+  FluxAdvanced,
+}

--- a/Devantler.KubernetesGenerator.KSail/Models/KSailClusterSpec.cs
+++ b/Devantler.KubernetesGenerator.KSail/Models/KSailClusterSpec.cs
@@ -1,4 +1,14 @@
+using Devantler.KubernetesGenerator.KSail.Models.Check;
+using Devantler.KubernetesGenerator.KSail.Models.Debug;
+using Devantler.KubernetesGenerator.KSail.Models.Down;
+using Devantler.KubernetesGenerator.KSail.Models.Gen;
+using Devantler.KubernetesGenerator.KSail.Models.Init;
+using Devantler.KubernetesGenerator.KSail.Models.List;
 using Devantler.KubernetesGenerator.KSail.Models.Registry;
+using Devantler.KubernetesGenerator.KSail.Models.Sops;
+using Devantler.KubernetesGenerator.KSail.Models.Start;
+using Devantler.KubernetesGenerator.KSail.Models.Up;
+using Devantler.KubernetesGenerator.KSail.Models.Update;
 
 namespace Devantler.KubernetesGenerator.KSail.Models;
 
@@ -8,22 +18,117 @@ namespace Devantler.KubernetesGenerator.KSail.Models;
 public class KSailClusterSpec
 {
   /// <summary>
-  /// The Kubernetes distribution to use for the KSail cluster.
+  /// The path to the kubeconfig file.
+  /// </summary>
+  public string? Kubeconfig { get; set; }
+
+  /// <summary>
+  /// The kube context.
+  /// </summary>
+  public string? Context { get; set; }
+
+  /// <summary>
+  /// The timeout for operations (in seconds).
+  /// </summary>
+  public int? Timeout { get; set; }
+
+  /// <summary>
+  /// The path to the directory that contains the manifests.
+  /// </summary>
+  public string? ManifestsDirectory { get; set; }
+
+  /// <summary>
+  /// The relative path to the directory that contains the root kustomization file.
+  /// </summary>
+  public string? KustomizationDirectory { get; set; }
+
+  /// <summary>
+  /// The path to the configuration file.
+  /// </summary>
+  public string? ConfigPath { get; set; }
+
+  /// <summary>
+  /// The Kubernetes distribution to use.
   /// </summary>
   public KSailKubernetesDistribution? Distribution { get; set; }
 
   /// <summary>
-  /// The GitOps tool to use for the KSail cluster.
+  /// The GitOps tool to use.
   /// </summary>
   public KSailGitOpsTool? GitOpsTool { get; set; }
 
   /// <summary>
-  /// The container engine to use for the KSail cluster.
+  /// The container engine to use.
   /// </summary>
   public KSailContainerEngine? ContainerEngine { get; set; }
+
+  /// <summary>
+  /// Whether to enable SOPS support.
+  /// </summary>
+  public bool? SOPS { get; set; }
 
   /// <summary>
   /// The registries to create for the KSail cluster to reconcile flux artifacts, and to proxy and cache images.
   /// </summary>
   public IEnumerable<KSailRegistry>? Registries { get; set; }
+
+  /// <summary>
+  /// The options to use for the 'check' command.
+  /// </summary>
+  public KSailCheckOptions? CheckOptions { get; set; }
+
+  /// <summary>
+  /// The options to use for the 'debug' command.
+  /// </summary>
+  public KSailDebugOptions? DebugOptions { get; set; }
+
+  /// <summary>
+  /// The options to use for the 'down' command.
+  /// </summary>
+  public KSailDownOptions? DownOptions { get; set; }
+
+  /// <summary>
+  /// The options to use for the 'gen' command.
+  /// </summary>
+  public KSailGenOptions? GenOptions { get; set; }
+
+  /// <summary>
+  /// The options to use for the 'init' command.
+  /// </summary>
+  public KSailInitOptions? InitOptions { get; set; }
+
+  /// <summary>
+  /// The options to use for the 'lint' command.
+  /// </summary>
+  public KSailInitOptions? LintOptions { get; set; }
+
+  /// <summary>
+  /// The options to use for the 'list' command.
+  /// </summary>
+  public KSailListOptions? ListOptions { get; set; }
+
+  /// <summary>
+  /// The options to use for the 'sops' command.
+  /// </summary>
+  public KSailSopsOptions? SopsOptions { get; set; }
+
+  /// <summary>
+  /// The options to use for the 'start' command.
+  /// </summary>
+  public KSailStartOptions? StartOptions { get; set; }
+
+  /// <summary>
+  /// The options to use for the 'stop' command.
+  /// </summary>
+  public KSailSopsOptions? StopOptions { get; set; }
+
+  /// <summary>
+  /// The options to use for the 'up' command.
+  /// </summary>
+  public KSailUpOptions? UpOptions { get; set; }
+
+  /// <summary>
+  /// The options to use for the 'update' command.
+  /// </summary>
+  public KSailUpdateOptions? UpdateOptions { get; set; }
 }

--- a/Devantler.KubernetesGenerator.KSail/Models/KSailClusterSpec.cs
+++ b/Devantler.KubernetesGenerator.KSail/Models/KSailClusterSpec.cs
@@ -3,10 +3,12 @@ using Devantler.KubernetesGenerator.KSail.Models.Debug;
 using Devantler.KubernetesGenerator.KSail.Models.Down;
 using Devantler.KubernetesGenerator.KSail.Models.Gen;
 using Devantler.KubernetesGenerator.KSail.Models.Init;
+using Devantler.KubernetesGenerator.KSail.Models.Lint;
 using Devantler.KubernetesGenerator.KSail.Models.List;
 using Devantler.KubernetesGenerator.KSail.Models.Registry;
 using Devantler.KubernetesGenerator.KSail.Models.Sops;
 using Devantler.KubernetesGenerator.KSail.Models.Start;
+using Devantler.KubernetesGenerator.KSail.Models.Stop;
 using Devantler.KubernetesGenerator.KSail.Models.Up;
 using Devantler.KubernetesGenerator.KSail.Models.Update;
 
@@ -65,7 +67,7 @@ public class KSailClusterSpec
   /// <summary>
   /// Whether to enable SOPS support.
   /// </summary>
-  public bool? SOPS { get; set; }
+  public bool? Sops { get; set; }
 
   /// <summary>
   /// The registries to create for the KSail cluster to reconcile flux artifacts, and to proxy and cache images.
@@ -100,7 +102,7 @@ public class KSailClusterSpec
   /// <summary>
   /// The options to use for the 'lint' command.
   /// </summary>
-  public KSailInitOptions? LintOptions { get; set; }
+  public KSailLintOptions? LintOptions { get; set; }
 
   /// <summary>
   /// The options to use for the 'list' command.
@@ -120,7 +122,7 @@ public class KSailClusterSpec
   /// <summary>
   /// The options to use for the 'stop' command.
   /// </summary>
-  public KSailSopsOptions? StopOptions { get; set; }
+  public KSailStopOptions? StopOptions { get; set; }
 
   /// <summary>
   /// The options to use for the 'up' command.

--- a/Devantler.KubernetesGenerator.KSail/Models/KSailContainerEngine.cs
+++ b/Devantler.KubernetesGenerator.KSail/Models/KSailContainerEngine.cs
@@ -1,3 +1,5 @@
+using System.Runtime.Serialization;
+
 namespace Devantler.KubernetesGenerator.KSail.Models;
 
 /// <summary>
@@ -8,5 +10,6 @@ public enum KSailContainerEngine
   /// <summary>
   /// Docker container engine.
   /// </summary>
+  [EnumMember(Value = "docker")]
   Docker
 }

--- a/Devantler.KubernetesGenerator.KSail/Models/Lint/KSailLintOptions.cs
+++ b/Devantler.KubernetesGenerator.KSail/Models/Lint/KSailLintOptions.cs
@@ -1,0 +1,8 @@
+namespace Devantler.KubernetesGenerator.KSail.Models.Lint;
+
+/// <summary>
+/// The options to use for the 'lint' command.
+/// </summary>
+public class KSailLintOptions
+{
+}

--- a/Devantler.KubernetesGenerator.KSail/Models/List/KSailListOptions.cs
+++ b/Devantler.KubernetesGenerator.KSail/Models/List/KSailListOptions.cs
@@ -1,0 +1,8 @@
+namespace Devantler.KubernetesGenerator.KSail.Models.List;
+
+/// <summary>
+/// The options to use for the 'list' command.
+/// </summary>
+public class KSailListOptions
+{
+}

--- a/Devantler.KubernetesGenerator.KSail/Models/Sops/KSailSopsOptions.cs
+++ b/Devantler.KubernetesGenerator.KSail/Models/Sops/KSailSopsOptions.cs
@@ -1,0 +1,8 @@
+namespace Devantler.KubernetesGenerator.KSail.Models.Sops;
+
+/// <summary>
+/// The options to use for the 'sops' command.
+/// </summary>
+public class KSailSopsOptions
+{
+}

--- a/Devantler.KubernetesGenerator.KSail/Models/Start/KSailStartOptions.cs
+++ b/Devantler.KubernetesGenerator.KSail/Models/Start/KSailStartOptions.cs
@@ -1,0 +1,8 @@
+namespace Devantler.KubernetesGenerator.KSail.Models.Start;
+
+/// <summary>
+/// The options to use for the 'start' command.
+/// </summary>
+public class KSailStartOptions
+{
+}

--- a/Devantler.KubernetesGenerator.KSail/Models/Stop/KSailStopOptions.cs
+++ b/Devantler.KubernetesGenerator.KSail/Models/Stop/KSailStopOptions.cs
@@ -1,0 +1,8 @@
+namespace Devantler.KubernetesGenerator.KSail.Models.Stop;
+
+/// <summary>
+/// The options to use for the 'stop' command.
+/// </summary>
+public class KSailStopOptions
+{
+}

--- a/Devantler.KubernetesGenerator.KSail/Models/Up/KSailUpOptions.cs
+++ b/Devantler.KubernetesGenerator.KSail/Models/Up/KSailUpOptions.cs
@@ -1,0 +1,17 @@
+namespace Devantler.KubernetesGenerator.KSail.Models.Up;
+
+/// <summary>
+/// The options to use for the 'up' command.
+/// </summary>
+public class KSailUpOptions
+{
+  /// <summary>
+  /// Whether to lint the manifests before applying them.
+  /// </summary>
+  public bool? Lint { get; set; }
+
+  /// <summary>
+  /// Whether to wait for reconciliation to succeed.
+  /// </summary>
+  public bool? Reconcile { get; set; }
+}

--- a/Devantler.KubernetesGenerator.KSail/Models/Update/KSailUpdateOptions.cs
+++ b/Devantler.KubernetesGenerator.KSail/Models/Update/KSailUpdateOptions.cs
@@ -1,0 +1,17 @@
+namespace Devantler.KubernetesGenerator.KSail.Models.Update;
+
+/// <summary>
+/// The options to use for the 'update' command.
+/// </summary>
+public class KSailUpdateOptions
+{
+  /// <summary>
+  /// Whether to lint the manifests before applying them.
+  /// </summary>
+  public bool? Lint { get; set; }
+
+  /// <summary>
+  /// Whether to wait for reconciliation to succeed.
+  /// </summary>
+  public bool? Reconcile { get; set; }
+}


### PR DESCRIPTION
This pull request adds command options for various KSail commands, including check, debug, down, gen, init, list, sops, start, stop, up, and update. These options allow for more customization and flexibility when using the KSail config to set defaults for the ksail tool.