### PR TITLE
Remove nullable HostPort property in KSailRegistry.cs

### DIFF
--- a/Devantler.KubernetesGenerator.KSail/Models/Registry/KSailRegistry.cs
+++ b/Devantler.KubernetesGenerator.KSail/Models/Registry/KSailRegistry.cs
@@ -13,7 +13,7 @@ public class KSailRegistry
   /// <summary>
   /// The host port of the registry (if applicable).
   /// </summary>
-  public int? HostPort { get; set; }
+  public int HostPort { get; set; }
 
   /// <summary>
   /// An optional proxy for the registry to use to proxy and cache images.


### PR DESCRIPTION
This pull request removes the nullable HostPort property in the KSailRegistry class. The HostPort property is changed from int? to int.