### PR TITLE
Update KindConfig to omit empty collections for runtimeconfig

### DIFF
--- a/Devantler.KubernetesGenerator.Core/BaseKubernetesGenerator.cs
+++ b/Devantler.KubernetesGenerator.Core/BaseKubernetesGenerator.cs
@@ -36,7 +36,7 @@ public class BaseKubernetesGenerator<T> : IKubernetesGenerator<T> where T : clas
       _ = Directory.CreateDirectory(outputDirectory);
     }
     string yaml = _serializer.Serialize(model);
-    // Append all text starting with ---
+
     if (!yaml.StartsWith("---", StringComparison.Ordinal))
     {
       yaml = $"---{Environment.NewLine}" + yaml;

--- a/Devantler.KubernetesGenerator.K3d.Tests/K3dConfigGeneratorTests/GenerateAsyncTests.cs
+++ b/Devantler.KubernetesGenerator.K3d.Tests/K3dConfigGeneratorTests/GenerateAsyncTests.cs
@@ -36,7 +36,6 @@ public class GenerateAsyncTests
         HostIP = "127.0.0.1",
         HostPort = "6445"
       },
-      Image = "rancher/k3s:v1.31.1-k3s1",
       Network = "my-custom-net",
       Subnet = "172.28.0.0/16",
       Token = "superSecretToken",

--- a/Devantler.KubernetesGenerator.K3d.Tests/K3dConfigGeneratorTests/k3d-config.full.verified.yaml
+++ b/Devantler.KubernetesGenerator.K3d.Tests/K3dConfigGeneratorTests/k3d-config.full.verified.yaml
@@ -9,7 +9,6 @@ kubeAPI:
   host: myhost.my.domain
   hostIP: 127.0.0.1
   hostPort: 6445
-image: rancher/k3s:v1.31.1-k3s1
 network: my-custom-net
 subnet: 172.28.0.0/16
 token: superSecretToken

--- a/Devantler.KubernetesGenerator.Kind.Tests/KindConfigGeneratorTests/kind-config.minimal.verified.yaml
+++ b/Devantler.KubernetesGenerator.Kind.Tests/KindConfigGeneratorTests/kind-config.minimal.verified.yaml
@@ -2,7 +2,6 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 name: kind-default
-runtimeConfig: {}
 containerdConfigPatches:
 - >-
   [plugins."io.containerd.grpc.v1.cri".registry]

--- a/Devantler.KubernetesGenerator.Kind/Models/KindConfig.cs
+++ b/Devantler.KubernetesGenerator.Kind/Models/KindConfig.cs
@@ -1,5 +1,6 @@
 using Devantler.KubernetesGenerator.Kind.Models.Networking;
 using Devantler.KubernetesGenerator.Kind.Models.Nodes;
+using YamlDotNet.Serialization;
 
 namespace Devantler.KubernetesGenerator.Kind.Models;
 
@@ -31,6 +32,7 @@ public class KindConfig
   /// <summary>
   /// A set of runtime configurations for the Kind cluster.
   /// </summary>
+  [YamlMember(DefaultValuesHandling = DefaultValuesHandling.OmitEmptyCollections)]
   public Dictionary<string, string> RuntimeConfig { get; } = [];
 
   /// <summary>


### PR DESCRIPTION
Modify the KindConfig class to omit empty collections in the runtime configuration when serialized to YAML. This change improves the output by preventing unnecessary empty fields.