### PR TITLE
Add silent mode option to FluxCLI execution

### DIFF
--- a/src/Devantler.KubernetesGenerator.Flux/BaseFluxGenerator.cs
+++ b/src/Devantler.KubernetesGenerator.Flux/BaseFluxGenerator.cs
@@ -32,7 +32,7 @@ public abstract class BaseFluxGenerator<T> : IKubernetesGenerator<T>
   /// <exception cref="KubernetesGeneratorException"></exception>
   public async Task RunFluxAsync(string outputPath, bool overwrite, List<string> arguments, string errorMessage, CancellationToken cancellationToken)
   {
-    var (exitCode, output) = await FluxCLI.Flux.RunAsync([.. arguments],
+    var (exitCode, output) = await FluxCLI.Flux.RunAsync([.. arguments], silent: true,
       cancellationToken: cancellationToken).ConfigureAwait(false);
     if (exitCode != 0)
       throw new KubernetesGeneratorException($"{errorMessage}: {output}");


### PR DESCRIPTION
Introduce a silent mode option for the FluxCLI execution in the RunFluxAsync method to suppress output during execution.