### PR TITLE
Remove default value for ContainerdConfigPatches in KindConfig model

### DIFF
--- a/src/Devantler.KubernetesGenerator.Kind/Models/KindConfig.cs
+++ b/src/Devantler.KubernetesGenerator.Kind/Models/KindConfig.cs
@@ -48,10 +48,5 @@ public class KindConfig
   /// <summary>
   /// A set of patches to apply to the containerd configuration.
   /// </summary>
-  public IEnumerable<string> ContainerdConfigPatches { get; set; } = [
-    """
-    [plugins."io.containerd.grpc.v1.cri".registry]
-      config_path = "/etc/containerd/certs.d"
-    """
-  ];
+  public IEnumerable<string>? ContainerdConfigPatches { get; set; }
 }

--- a/tests/Devantler.KubernetesGenerator.Kind.Tests/KindConfigGeneratorTests/kind-config.minimal.verified.yaml
+++ b/tests/Devantler.KubernetesGenerator.Kind.Tests/KindConfigGeneratorTests/kind-config.minimal.verified.yaml
@@ -2,7 +2,3 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 name: kind-default
-containerdConfigPatches:
-- >-
-  [plugins."io.containerd.grpc.v1.cri".registry]
-    config_path = "/etc/containerd/certs.d"


### PR DESCRIPTION
Removing the default value for `ContainerdConfigPatches` allows for more flexible configuration in the KindConfig model. This change eliminates the hardcoded default, enabling users to define their own patches as needed.