### PR TITLE
Add EnumMember attribute to SOPS and update YAML case sensitivity

### DIFF
--- a/src/Devantler.KubernetesGenerator.Flux/Models/Kustomization/FluxKustomizationSpecDecryptionProvider.cs
+++ b/src/Devantler.KubernetesGenerator.Flux/Models/Kustomization/FluxKustomizationSpecDecryptionProvider.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Runtime.Serialization;
 
 namespace Devantler.KubernetesGenerator.Flux.Models.Kustomization;
 
@@ -11,5 +12,6 @@ public enum FluxKustomizationSpecDecryptionProvider
   /// The provider to use for decryption is sops.
   /// </summary>
   [Description("sops")]
+  [EnumMember(Value = "sops")]
   SOPS
 }

--- a/tests/Devantler.KubernetesGenerator.Flux.Tests/FluxKustomizationGeneratorTests/kustomization-complex.yaml.verified.yaml
+++ b/tests/Devantler.KubernetesGenerator.Flux.Tests/FluxKustomizationGeneratorTests/kustomization-complex.yaml.verified.yaml
@@ -37,6 +37,6 @@ spec:
     secretRef:
       name: kubeconfig-secret
   decryption:
-    provider: SOPS
+    provider: sops
     secretRef:
       name: sops-secret


### PR DESCRIPTION
Add the `EnumMember` attribute to the SOPS enum for improved serialization and update the YAML configuration to ensure case sensitivity aligns with the enum definition.